### PR TITLE
Safari使用時にツールパレットを移動すると描画時にもカーソル位置に付いてきて描画できなくなっていた問題を修正。

### DIFF
--- a/extensions/mascot/mascot.js
+++ b/extensions/mascot/mascot.js
@@ -204,8 +204,6 @@ export default class Mascot {
             this.baseX = e.pageX;
             this.baseY = e.pageY;
             //console.log('down', e.pageX, e.pageY);
-            // イベントリスナー解除用
-            const controller = new AbortController();
             // ドラッグ中
             const calcPosition = (x, y) => {
                 //ドラッグ範囲制限
@@ -224,7 +222,7 @@ export default class Mascot {
                 if (new_y >= limit_height) new_y = limit_height;
                 return { x: new_x, y: new_y };
             }
-            window.addEventListener('pointermove', (e) => {
+            const onPointerMove = (e) => {
                 e.stopPropagation();
                 let pos = calcPosition(e.pageX, e.pageY);
                 //マウスが動いた場所に要素を動かす
@@ -232,10 +230,9 @@ export default class Mascot {
                     pos.x,
                     pos.y
                 );
-            }, { signal: controller.signal });
-
+            }
             // ドロップ
-            window.addEventListener('pointerup', (e) => {
+            const onPointerUp = (e) => {
                 e.stopPropagation();
                 let pos = calcPosition(e.pageX, e.pageY);
                 //マウスが動いた場所に要素を動かす
@@ -244,8 +241,11 @@ export default class Mascot {
                     pos.y
                 );
                 // イベントリスナー解除
-                controller.abort();
-            }, { signal: controller.signal });
+                window.removeEventListener('pointermove', onPointerMove);
+                window.removeEventListener('pointerup', onPointerUp);
+            }
+            window.addEventListener('pointermove', onPointerMove);
+            window.addEventListener('pointerup', onPointerUp);
         });
     }
     //

--- a/src/js/dragwindow.js
+++ b/src/js/dragwindow.js
@@ -226,17 +226,17 @@ export class DragWindow {
 
             return { x: new_x, y: new_y };
         }
-        window.addEventListener('pointermove', (e) => {
+		const onPointerMove=(e)=>{
+			
             let pos = calcPosition(e.pageX, e.pageY);
             //マウスが動いた場所に要素を動かす
             objSystem.setPosition(
                 pos.x,
                 pos.y
             );
-        }, { signal: controller.signal });
-
+		};
+		const onPointerUp = (e) => {
         // ドロップ
-        window.addEventListener('pointerup', (e) => {
             let pos = calcPosition(e.pageX, e.pageY);
             //マウスが動いた場所に要素を動かす
             objSystem.setPosition(
@@ -248,9 +248,13 @@ export class DragWindow {
             this.axpObj.configSystem.saveConfig('WDPOS_' + objSystem.windowElement.id, savedata);
             // イベントリスナー解除
             controller.abort();
-        }, { signal: controller.signal });
-    }
-    /**
+			window.removeEventListener('pointermove', onPointerMove);
+			window.removeEventListener('pointerup', onPointerUp);
+		};
+        window.addEventListener('pointermove',onPointerMove,{ signal: controller.signal });
+        window.addEventListener('pointerup',onPointerUp,{ signal: controller.signal });
+	}
+		/**
      * 指定idと一致したツールウィンドウ要素をサーチし、見つかった場合、初期座標を更新する
      * @param {*} id ツールウィンドウ要素のID
      * @param {*} x left座標

--- a/src/js/dragwindow.js
+++ b/src/js/dragwindow.js
@@ -204,9 +204,6 @@ export class DragWindow {
         drag_x = e.pageX - elem.offsetLeft;
         drag_y = e.pageY - elem.offsetTop;
 
-        // イベントリスナー解除用
-        const controller = new AbortController();
-
         // ドラッグ中
 
         const calcPosition = (x, y) => {
@@ -226,17 +223,17 @@ export class DragWindow {
 
             return { x: new_x, y: new_y };
         }
-		const onPointerMove=(e)=>{
-			
+        const onPointerMove = (e) => {
+
             let pos = calcPosition(e.pageX, e.pageY);
             //マウスが動いた場所に要素を動かす
             objSystem.setPosition(
                 pos.x,
                 pos.y
             );
-		};
-		const onPointerUp = (e) => {
-        // ドロップ
+        };
+        const onPointerUp = (e) => {
+            // ドロップ
             let pos = calcPosition(e.pageX, e.pageY);
             //マウスが動いた場所に要素を動かす
             objSystem.setPosition(
@@ -247,14 +244,13 @@ export class DragWindow {
             let savedata = pos.x + ',' + pos.y;
             this.axpObj.configSystem.saveConfig('WDPOS_' + objSystem.windowElement.id, savedata);
             // イベントリスナー解除
-            controller.abort();
-			window.removeEventListener('pointermove', onPointerMove);
-			window.removeEventListener('pointerup', onPointerUp);
-		};
-        window.addEventListener('pointermove',onPointerMove,{ signal: controller.signal });
-        window.addEventListener('pointerup',onPointerUp,{ signal: controller.signal });
-	}
-		/**
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
+        };
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
+    }
+    /**
      * 指定idと一致したツールウィンドウ要素をサーチし、見つかった場合、初期座標を更新する
      * @param {*} id ツールウィンドウ要素のID
      * @param {*} x left座標

--- a/src/js/window_layer.js
+++ b/src/js/window_layer.js
@@ -1137,10 +1137,8 @@ export class LayerSystem extends ToolWindow {
         data.cloneName = util.insertClone(target, util.index(target));
         target.style.width = `${targetW}px`;
         target.classList.add('axpc_onGRAB');
-        // イベントリスナー解除用
-        const controller = new AbortController();
         // ドラッグ中
-        window.addEventListener('pointermove', (e) => {
+        const onPointerMove = (e) => {
             //console.log('move');
             const target = data.target;
             const pageX = e.pageX;
@@ -1150,9 +1148,9 @@ export class LayerSystem extends ToolWindow {
             target.style.left = `${targetPosL}px`;
             target.style.top = `${targetPosT}px`;
             util.swap(target);
-        }, { signal: controller.signal });
+        }
         // ドロップ
-        window.addEventListener('pointerup', (e) => {
+        const onPointerUp = (e) => {
             //console.log('up');
             //console.log('e:', e.currentTarget);
             const target = data.target;
@@ -1163,7 +1161,8 @@ export class LayerSystem extends ToolWindow {
             target.removeAttribute('style');
             target.classList.remove('axpc_onGRAB');
             // イベントリスナー解除
-            controller.abort();
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
 
             // 操作終了後、実際に入替処理が行われたどうか判定する
             var elem = document.querySelectorAll('#axp_layer_ul_layerBox>li');
@@ -1197,7 +1196,9 @@ export class LayerSystem extends ToolWindow {
                 this.updateLayerIndex();
                 this.updateCanvas();
             }
-        }, { signal: controller.signal });
+        }
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
     }
     // カレントレイヤー更新
     setCurrentLayer(targetElement) {

--- a/src/js/window_palette.js
+++ b/src/js/window_palette.js
@@ -226,10 +226,8 @@ export class ColorPaletteSystem extends ToolWindow {
         ps_data.cloneName = palette_sorting.insertClone(target, palette_sorting.index(target));
         // クラス名axpc_onGRABを付与することで、CSSで指定してあるposition: absolute;が有効となる→自由にドラッグができる
         target.classList.add('axpc_onGRAB');
-        // イベントリスナー解除用
-        const controller = new AbortController();
         // ドラッグ中
-        window.addEventListener('pointermove', (e) => {
+        const onPointerMove = (e) => {
             const target = ps_data.target;
             const pageX = e.pageX;
             const pageY = e.pageY;
@@ -238,9 +236,9 @@ export class ColorPaletteSystem extends ToolWindow {
             target.style.left = `${targetPosL}px`;
             target.style.top = `${targetPosT}px`;
             palette_sorting.swap(target);
-        }, { signal: controller.signal });
+        }
         // ドロップ
-        window.addEventListener('pointerup', (e) => {
+        const onPointerUp = (e) => {
             const target = ps_data.target;
             const cloneSelector = `.${ps_data.cloneName}`;
             const clone = document.querySelector(cloneSelector);
@@ -248,7 +246,8 @@ export class ColorPaletteSystem extends ToolWindow {
             clone.remove();
             target.classList.remove('axpc_onGRAB');
             // イベントリスナー解除
-            controller.abort();
+            window.removeEventListener('pointermove', onPointerMove);
+            window.removeEventListener('pointerup', onPointerUp);
 
             // 操作終了時のインデックス
             ps_data.idx_dest = palette_sorting.index(target);
@@ -266,7 +265,9 @@ export class ColorPaletteSystem extends ToolWindow {
                 // DBへ保存
                 this.axpObj.saveSystem.save_palette(this.currentPalette.palette);
             }
-        }, { signal: controller.signal });
+        }
+        window.addEventListener('pointermove', onPointerMove);
+        window.addEventListener('pointerup', onPointerUp);
     }
 
     getColor() {


### PR DESCRIPTION
すばらしいペイントツールの開発ありがとうございます。
さて、早速ですが、お絵かき掲示板交流サイトに導入したところ、Mac+Safariユーザーの方複数名から描画できないという報告が上がりました。
ツールパレットをほんの少しでも移動すると、その後もツールパレットが移動し続け、描画時のカーソル位置にパレットが付いて来てしまい描画できないそうです。
私の環境はWindowsとAndroidなのでSafariは環境を持っているユーザーの方にテストしてもらっています。

```
        // ドロップ
        window.addEventListener('pointerup', (e) => {
            let pos = calcPosition(e.pageX, e.pageY);
            //マウスが動いた場所に要素を動かす
            objSystem.setPosition(
                pos.x,
                pos.y
            );
            //ウィンドウの座標をデータ化してコンフィグオブジェクトに格納
            let savedata = pos.x + ',' + pos.y;
            this.axpObj.configSystem.saveConfig('WDPOS_' + objSystem.windowElement.id, savedata);
            // イベントリスナー解除
            controller.abort();
        }, { signal: controller.signal });

```
Safariでは、
  ```
        // イベントリスナー解除
            controller.abort();
  
```
でイベントリスナーが解除できない事が原因かもしれないという推測をして、
addEventListenerと、removeEventListenerを使ったイベントリスナーの解除を行ったところ、Mac+Safari環境でも問題なく描画できるようになったという報告がありましたので、プルリクエストさせていただきました。

ただ開発コミュニティのガイドラインが理解できていないかもしれず、失礼がありましたらすみません。

Mergeする、しないはおまかせして、コードを含めた形で提出して、どちらかというとMac+Safariでの動作に問題がある事をお知らせするためにプルリクエストを開いてみました。
よろしくお願いいたします。
