### PR TITLE
・ロード時のdraftImageFileとoekaki_idの判定手順修正

### DIFF
--- a/src/js/etc.js
+++ b/src/js/etc.js
@@ -62,8 +62,13 @@ export function getBrowserType() {
 }
 
 // ファイルパスからファイル名部分だけ切り抜いて返却する
-export function getFileNameFromURL(url) {
-    return url.match(".+/(.+?)([?#;].*)?$")[1];
+export function getFileNameFromURL(input) {
+    const baseUrl = window.location.href; // 現在のページのURL
+    const absoluteUrl = new URL(input, baseUrl).href;
+    // ファイル名抽出（例として、最後のスラッシュ以降の部分を取得）
+    const fileName = absoluteUrl.split('/').pop();
+    //console.log(input, fileName);
+    return fileName;
 }
 
 /**

--- a/src/js/saveload.js
+++ b/src/js/saveload.js
@@ -169,15 +169,18 @@ export class SaveSystem {
             stringTime = stringTime.replace(/ss/, ("0" + value.created.getSeconds()).slice(-2));
             newDivTime.textContent = stringTime;
             // 基にしたoekaki_id(draftImageFile優先)
-            if (value.draftImageFile !== undefined) {
-                if (value.draftImageFile !== null) {
-                    newDivRefId.textContent = '[基]' + getFileNameFromURL(value.draftImageFile);
-                }
-            } else if (value.oekaki_id !== undefined) {
+            let refIdText = '';
+            if (value.oekaki_id !== undefined) {
                 if (value.oekaki_id !== null) {
-                    newDivRefId.textContent = '[基]' + value.oekaki_id;
+                    refIdText = '[基]' + value.oekaki_id;
                 }
             }
+            if (value.draftImageFile !== undefined) {
+                if (value.draftImageFile !== null) {
+                    refIdText = '[基]' + getFileNameFromURL(value.draftImageFile);
+                }
+            }
+            newDivRefId.textContent = refIdText;
             newDiv.appendChild(newDivDate);
             newDiv.appendChild(newDivTime);
             newDiv.appendChild(newDivRefId);


### PR DESCRIPTION
#35 draftImageFileがnullの時に、oekaki_idが設定されていても無視されてしまう不具合
* draftImageFileがnullの時に、oekaki_idが設定されていても無視されてしまう不具合の修正
* draftImageFileに'1.png'のようにファイル名単体を指定した場合に、ファイル名取得関数getFileNameFromURLでエラーが発生する不具合の修正