### PR TITLE
色作成ツールの透明色ボタンの背景の格子模様のサイズを調整

### DIFF
--- a/src/css/window_makecolor.css
+++ b/src/css/window_makecolor.css
@@ -91,6 +91,7 @@
     grid-area: 3/8/5/11;
     margin: 1px;
     isolation: isolate;
+    background-size: 14px 14px;
 }
 
 /* コード入力 */


### PR DESCRIPTION
色作成ツールウィンドウの透明色ボタンの背景の格子模様を
ボタンのサイズに合わせて調整しました
![image](https://github.com/user-attachments/assets/7dfcfe45-a9d5-48d9-aab9-5ed63a343881)
