### PR TITLE
設定タブ　axpc_numberクラスのheightをmin-heightに変更

### DIFF
--- a/src/css/input_number.css
+++ b/src/css/input_number.css
@@ -1,6 +1,6 @@
 /* 数値入力共通 */
 .axpc_number {
-    height: 30px;
+    min-height: 30px;
     margin: 4px 0;
 }
 


### PR DESCRIPTION
### CSSの調整
設定タブのinput type="number"部分の外枠divの**height**指定を**min-heigh**t指定に変更
折り返し時の行間対策
![image-1](https://github.com/user-attachments/assets/841e7f53-fd1c-4966-a712-6081501f67eb)
