### PR TITLE
3箇所の余白の表示微細調整

### DIFF
--- a/src/css/axnospaint.css
+++ b/src/css/axnospaint.css
@@ -128,7 +128,7 @@ body {
 
   #axp_main_checkbox_hamburger:checked~div>div {
     border: 1px solid #333;
-    height: 2.5em;
+    height: 3em;
     padding: 0.5em;
     transition: height 400ms cubic-bezier(0.23, 1, 0.32, 1);
   }
@@ -301,6 +301,5 @@ body {
 }
 
 #axp_footer_div_icon {
-  margin-left: 8px;
-  margin-top: 2px;
+  margin: auto 0 auto 8px;
 }

--- a/src/css/input_radio.css
+++ b/src/css/input_radio.css
@@ -40,6 +40,7 @@
     width: 100px;
     margin: 2px;
     border-radius: 50px;
+    vertical-align: middle;
 }
 
 .axpc_radio button:hover {


### PR DESCRIPTION
- axnospaint.css
  - ハンバーガーメニュー内ボタン（`#axp_main_checkbox_hamburger:checked~div>div`）のheight微調整
  - フッター領域アイコン（`#axp_footer_div_icon`）の上下調整
- input_radio.css
  - ラジオボタンを`vertical-align: middle;`で上下位置調整