### PR TITLE
バケツ使用時にぼかし度の0リセット

### DIFF
--- a/src/js/pendefine/fill.js
+++ b/src/js/pendefine/fill.js
@@ -39,7 +39,7 @@ export class Fill extends PenObj {
     this.CANVAS.brush_ctx.lineCap = 'round';
     this.CANVAS.brush_ctx.lineJoin = 'round';
     // ぼかし無し
-    //        this.blur(0);
+    this.blur(0);
   }
   // 描画開始
   start(x, y, e, option) {


### PR DESCRIPTION
#92 直前に使用したぼかし度がバケツに反映されてしまう不具合
不具合の修正